### PR TITLE
[feat] #28 메인페이지 api 구현

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/domain/ChatRoom.java
@@ -30,7 +30,7 @@ public class ChatRoom extends BaseTimeEntity {
     private User user2;
 
     @Column(name = "active", nullable = false)
-    private Boolean active;
+    private Boolean roomActive;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/RoomRepository.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/RoomRepository.java
@@ -2,9 +2,13 @@ package com.moodmate.moodmatebe.domain.chat.repository;
 
 import com.moodmate.moodmatebe.domain.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface RoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByRoomId(Long roomId);
+    @Query("SELECT cr FROM chat_room cr WHERE (cr.user1.userId = :userId OR cr.user2.userId = :userId) AND cr.roomActive = true ORDER BY cr.createdAt DESC")
+    Optional<ChatRoom> findLatestActiveByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/RoomRepository.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/RoomRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 public interface RoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByRoomId(Long roomId);
-    @Query("SELECT cr FROM chat_room cr WHERE (cr.user1.userId = :userId OR cr.user2.userId = :userId) AND cr.roomActive = true ORDER BY cr.createdAt DESC")
-    Optional<ChatRoom> findLatestActiveByUserId(@Param("userId") Long userId);
+    @Query("SELECT cr FROM chat_room cr WHERE (cr.user1.userId = :userId OR cr.user2.userId = :userId) AND cr.roomActive = TRUE")
+    Optional<ChatRoom> findActiveChatRoomByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
@@ -8,14 +8,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequiredArgsConstructor
+@RequestMapping("/user")
 public class UserController {
 
     private final UserService userService;
 
-    // TODO: OAuthDetails가 아직 없음
 //    @Operation(summary = "메인 페이지 불러오기")
 //    @ApiResponses({
 //            @ApiResponse(responseCode = "200"),
@@ -28,12 +29,11 @@ public class UserController {
 
     @Operation(summary = "메인 페이지 불러오기")
     @ApiResponses({
-            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "200")
     })
     @GetMapping("/main")
     public MainPageResponse getMainPage() {
         // TODO: 임시값
-        Long userId = 1L;
-        return userService.getMainPage(userId);
+        return userService.getMainPage(1L);
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
@@ -1,0 +1,39 @@
+package com.moodmate.moodmatebe.domain.user.api;
+
+import com.moodmate.moodmatebe.domain.user.application.UserService;
+import com.moodmate.moodmatebe.domain.user.dto.MainPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    // TODO: OAuthDetails가 아직 없음
+//    @Operation(summary = "메인 페이지 불러오기")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200"),
+//    })
+//    @GetMapping("/main")
+//    public MainPageResponse getMainPage(@AuthenticationPrincipal AuthDetails authDetails) {
+//
+//        return userService.getMainPage();
+//    }
+
+    @Operation(summary = "메인 페이지 불러오기")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+    })
+    @GetMapping("/main")
+    public MainPageResponse getMainPage() {
+        // TODO: 임시값
+        Long userId = 1L;
+        return userService.getMainPage(userId);
+    }
+}

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
@@ -1,0 +1,42 @@
+package com.moodmate.moodmatebe.domain.user.application;
+
+import com.moodmate.moodmatebe.domain.chat.domain.ChatRoom;
+import com.moodmate.moodmatebe.domain.chat.repository.RoomRepository;
+import com.moodmate.moodmatebe.domain.user.domain.Gender;
+import com.moodmate.moodmatebe.domain.user.domain.User;
+import com.moodmate.moodmatebe.domain.user.dto.MainPageResponse;
+import com.moodmate.moodmatebe.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
+    private final Long ROOM_NOT_EXIST = -1L;
+
+    public MainPageResponse getMainPage(Long userId){
+
+        Gender userGender = null;
+        Boolean userMatchActive = false;
+        Long roomId = ROOM_NOT_EXIST;
+        Boolean roomActive = false;
+
+        Optional<User> user = userRepository.findById(userId);
+        Optional<ChatRoom> chatRoom = roomRepository.findLatestActiveByUserId(userId);
+
+        if(user.isPresent()){
+            userGender = user.get().getUserGender();
+            userMatchActive = user.get().getUserMatchActive();
+        }
+        if(chatRoom.isPresent()){
+            roomId = chatRoom.get().getRoomId();
+            roomActive = chatRoom.get().getRoomActive();
+        }
+
+        return new MainPageResponse(userId, userGender, userMatchActive, roomId, roomActive);
+    }
+}

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
         Boolean roomActive = false;
 
         Optional<User> user = userRepository.findById(userId);
-        Optional<ChatRoom> chatRoom = roomRepository.findLatestActiveByUserId(userId);
+        Optional<ChatRoom> chatRoom = roomRepository.findActiveChatRoomByUserId(userId);
 
         if(user.isPresent()){
             userGender = user.get().getUserGender();
@@ -37,6 +37,8 @@ public class UserService {
             roomActive = chatRoom.get().getRoomActive();
         }
 
-        return new MainPageResponse(userId, userGender, userMatchActive, roomId, roomActive);
+        MainPageResponse mainPageResponse = new MainPageResponse(userId, userGender, userMatchActive, roomId, roomActive);
+
+        return mainPageResponse;
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/domain/User.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/domain/User.java
@@ -35,7 +35,7 @@ public class User extends BaseTimeEntity {
     private Byte userAge;
 
     @ElementCollection
-    @CollectionTable(name = "user_keywords", joinColumns = @JoinColumn(name = "user_no"))
+    @CollectionTable(name = "user_keywords", joinColumns = @JoinColumn(name = "user_id"))
     @Column(name = "user_keywords", nullable = false)
     private List<String> userKeywords;
 

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/domain/User.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/domain/User.java
@@ -1,11 +1,14 @@
 package com.moodmate.moodmatebe.domain.user.domain;
 
 import com.moodmate.moodmatebe.global.shared.entity.BaseTimeEntity;
+import jakarta.annotation.PreDestroy;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,10 +32,11 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_gender", nullable = false)
     private Gender userGender;
 
-    @Column(name = "user_age", nullable = false)
-    @Min(value = 20, message = "Age should not be less than 20")
-    @Max(value = 30, message = "Age should not be greater than 30")
-    private Byte userAge;
+    @Column(name = "user_nickname", nullable = true)
+    private String userNickname;
+
+    @Column(name = "year", nullable = true)
+    private Integer year;
 
     @ElementCollection
     @CollectionTable(name = "user_keywords", joinColumns = @JoinColumn(name = "user_id"))
@@ -42,6 +46,15 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_department", nullable = false)
     private String userDepartment;
 
+    @Column(name = "user_match_active")
+    @ColumnDefault("true")
+    private Boolean userMatchActive;
+
     @Column()
     private LocalDateTime deletedAt;
+
+    @PreDestroy()
+    public void preDestroy() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/dto/MainPageResponse.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/dto/MainPageResponse.java
@@ -1,0 +1,18 @@
+package com.moodmate.moodmatebe.domain.user.dto;
+
+import com.moodmate.moodmatebe.domain.user.domain.Gender;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MainPageResponse {
+    private Long userId;
+    private Gender userGender;
+    private Boolean userMatchActive;
+
+    private Long roomId;
+    private Boolean roomActive;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
메인페이지를 로드할 수 있는 데이터를 반환하는 api를 개발했습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
현재 로그인 기능이 구현되어 있지 않아, 임시로 기능만 작동하도록 구현하였습니다. 추후 로그인 구현 완료 시 Token에서 유저 정보를 추출하는 방식으로만 변경하면 됩니다.

swagger에서는 404 에러가 나는데 이유를 찾고 있습니다. 쿼리문은 제대로 작동하여 데이터가 반환됩니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
임의의 userId에 대하여 http://localhost:8080/user/main 을 실행하면
```
    private Long userId;
    private Gender userGender;
    private Boolean userMatchActive;

    private Long roomId;
    private Boolean roomActive;
```
아래 데이터들을 반환합니다.

이때, 각 값들의 초기화값은 다음과 같습니다
```
        Gender userGender = null;
        Boolean userMatchActive = false;
        Long roomId = ROOM_NOT_EXIST; // -1
        Boolean roomActive = false;
```
즉 프론트에서 roomId가 -1일 경우 room이 없다고 판단하면 됩니다. 

<br>

## 5. 추가 사항
가독성을 위해 일부 칼럼명을 변경하고, 서버를 재시작해도 데이터베이스에 데이터를 유지하기 위해서 update를 사용하는 등의 작업을 추가했습니다. 

어차피 이 PR 추후 로그인 구현 후에 수정되어야 해서 크게 리팩토링을 진행하지 않았습니다. 이 점 감안해주시기 바랍니다.