### PR TITLE
[fix] #40 채팅내역 조회 DTO 변경

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/api/MessageController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/api/MessageController.java
@@ -3,12 +3,12 @@ package com.moodmate.moodmatebe.domain.chat.api;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.moodmate.moodmatebe.domain.chat.application.ChatRoomService;
 import com.moodmate.moodmatebe.domain.chat.application.ChatService;
-import com.moodmate.moodmatebe.domain.chat.dto.ChatMessageDto;
-import com.moodmate.moodmatebe.domain.chat.dto.MessageDto;
-import com.moodmate.moodmatebe.domain.chat.dto.RedisChatMessageDto;
+import com.moodmate.moodmatebe.domain.chat.dto.*;
 import com.moodmate.moodmatebe.domain.chat.redis.RedisPublisher;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -20,10 +20,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import java.time.LocalDateTime;
-
 @Controller
 @RequiredArgsConstructor
+@Slf4j
 public class MessageController {
     private final ChatService chatService;
     private final RedisPublisher redisPublisher;
@@ -40,10 +39,13 @@ public class MessageController {
 
     @Operation(summary = "채팅내역 조회", description = "채팅내역을 조회합니다.")
     @GetMapping("/chat")
-    ResponseEntity<List<MessageDto>> getChatMessage(
-            @RequestParam Long roomId, @RequestParam int size, @RequestParam int page) throws JsonProcessingException {
+    ResponseEntity<ChatResponseDto> getChatMessage(
+            @RequestParam Long roomId,
+            @RequestParam Long userId, @RequestParam int size, @RequestParam int page) throws JsonProcessingException {
         List<MessageDto> message = chatService.getMessage(roomId, size, page);
-        return ResponseEntity.ok(message);
-
+        ChatPageableDto pageable = chatService.getPageable(roomId, size, page);
+        ChatUserDto user = chatService.getUserInfo(userId);
+        ChatResponseDto responseDto = new ChatResponseDto(user,pageable,message);
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/api/MessageController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/api/MessageController.java
@@ -7,7 +7,6 @@ import com.moodmate.moodmatebe.domain.chat.dto.*;
 import com.moodmate.moodmatebe.domain.chat.redis.RedisPublisher;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +21,6 @@ import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
-@Slf4j
 public class MessageController {
     private final ChatService chatService;
     private final RedisPublisher redisPublisher;

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/api/MessageController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/api/MessageController.java
@@ -25,12 +25,13 @@ public class MessageController {
     private final ChatService chatService;
     private final RedisPublisher redisPublisher;
     private final ChatRoomService chatRoomService;
+
     @Operation(summary = "실시간 채팅", description = "실시간으로 채팅 메시지를 보냅니다.")
     @MessageMapping("/chat")
     @SendTo("/sub/chat")
-    public void handleChatMessage(ChatMessageDto messageDto){
+    public void handleChatMessage(ChatMessageDto messageDto) {
         chatRoomService.enterChatRoom(messageDto.getRoomId());
-        RedisChatMessageDto redisChatMessageDto = new RedisChatMessageDto(null,messageDto.getUserId(),messageDto.getRoomId(),messageDto.getContent(),true, LocalDateTime.now());
+        RedisChatMessageDto redisChatMessageDto = new RedisChatMessageDto(null, messageDto.getUserId(), messageDto.getRoomId(), messageDto.getContent(), true, LocalDateTime.now());
         redisPublisher.publish(new ChannelTopic("/sub/chat/" + messageDto.getRoomId()), redisChatMessageDto);
         chatService.saveMessage(redisChatMessageDto);
     }
@@ -43,7 +44,7 @@ public class MessageController {
         List<MessageDto> message = chatService.getMessage(roomId, size, page);
         ChatPageableDto pageable = chatService.getPageable(roomId, size, page);
         ChatUserDto user = chatService.getUserInfo(userId);
-        ChatResponseDto responseDto = new ChatResponseDto(user,pageable,message);
+        ChatResponseDto responseDto = new ChatResponseDto(user, pageable, message);
         return ResponseEntity.ok(responseDto);
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/application/ChatRoomService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/application/ChatRoomService.java
@@ -16,11 +16,11 @@ public class ChatRoomService {
 
     public void enterChatRoom(Long roomId) throws ChatRoomNotFoundException, ConnectionException {
         ChannelTopic topic = new ChannelTopic("/sub/chat/" + roomId);
-        try{
+        try {
             redisMessageListener.addMessageListener(redisSubscriber, topic);
-        }catch (ChatRoomNotFoundException e){
+        } catch (ChatRoomNotFoundException e) {
             throw new ChatRoomNotFoundException();
-        }catch (ConnectionException e){
+        } catch (ConnectionException e) {
             throw new ConnectionException();
         }
     }

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/application/ChatService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/application/ChatService.java
@@ -47,7 +47,7 @@ public class ChatService {
         messageRepository.save(chatMessage);
         Long messageId = redisMessageIdGenerator.generateUniqueId(chatMessageDto.getRoomId().toString());
         chatMessageDto.setMessageId(messageId);
-        chatRedistemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatMessage.class));
+        chatRedistemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(RedisChatMessageDto.class));
         chatRedistemplate.opsForList().rightPush(chatMessageDto.getRoomId().toString(), chatMessageDto);
     }
 
@@ -79,7 +79,7 @@ public class ChatService {
     }
     public ChatUserDto getUserInfo(Long userId){
         User user = getUser(userId);
-        ChatUserDto chatUserDto = new ChatUserDto(user.getUserGender(),"testNickname");
+        ChatUserDto chatUserDto = new ChatUserDto(user.getUserGender(),user.getUserNickname());
         return chatUserDto;
     }
 

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/application/ChatService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/application/ChatService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moodmate.moodmatebe.domain.chat.domain.ChatMessage;
 import com.moodmate.moodmatebe.domain.chat.domain.ChatRoom;
+import com.moodmate.moodmatebe.domain.chat.dto.ChatPageableDto;
+import com.moodmate.moodmatebe.domain.chat.dto.ChatUserDto;
 import com.moodmate.moodmatebe.domain.chat.dto.MessageDto;
 import com.moodmate.moodmatebe.domain.chat.dto.RedisChatMessageDto;
 import com.moodmate.moodmatebe.domain.chat.exception.ChatRoomNotFoundException;
@@ -15,6 +17,7 @@ import com.moodmate.moodmatebe.domain.user.domain.User;
 import com.moodmate.moodmatebe.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -29,6 +32,7 @@ import java.util.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ChatService {
     private final RedisTemplate<String, RedisChatMessageDto> chatRedistemplate;
     private final RoomRepository roomRepository;
@@ -68,6 +72,19 @@ public class ChatService {
         }
         return messageList;
     }
+    public ChatPageableDto getPageable(Long roomId, int size, int page){
+        ChatRoom room = getChatRoom(roomId);
+        int totalElements = messageRepository.countByRoom(room);
+        int totalPages = (int) Math.ceil((double) totalElements / size);
+        ChatPageableDto chatPageableDto = new ChatPageableDto(size,page,totalPages,totalElements);
+        return chatPageableDto;
+    }
+    public ChatUserDto getUserInfo(Long userId){
+        User user = getUser(userId);
+        ChatUserDto chatUserDto = new ChatUserDto(user.getUserGender(),"testNickname");
+        return chatUserDto;
+    }
+
     private List<RedisChatMessageDto> getRedisMessages(Long roomId, int size, int page) {
         int start = (page - 1) * size;
         int end = start + size - 1;

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/application/ChatService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/application/ChatService.java
@@ -17,7 +17,6 @@ import com.moodmate.moodmatebe.domain.user.domain.User;
 import com.moodmate.moodmatebe.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -32,7 +31,6 @@ import java.util.*;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class ChatService {
     private final RedisTemplate<String, RedisChatMessageDto> chatRedistemplate;
     private final RoomRepository roomRepository;

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/application/ChatService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/application/ChatService.java
@@ -70,16 +70,18 @@ public class ChatService {
         }
         return messageList;
     }
-    public ChatPageableDto getPageable(Long roomId, int size, int page){
+
+    public ChatPageableDto getPageable(Long roomId, int size, int page) {
         ChatRoom room = getChatRoom(roomId);
         int totalElements = messageRepository.countByRoom(room);
         int totalPages = (int) Math.ceil((double) totalElements / size);
-        ChatPageableDto chatPageableDto = new ChatPageableDto(size,page,totalPages,totalElements);
+        ChatPageableDto chatPageableDto = new ChatPageableDto(size, page, totalPages, totalElements);
         return chatPageableDto;
     }
-    public ChatUserDto getUserInfo(Long userId){
+
+    public ChatUserDto getUserInfo(Long userId) {
         User user = getUser(userId);
-        ChatUserDto chatUserDto = new ChatUserDto(user.getUserGender(),user.getUserNickname());
+        ChatUserDto chatUserDto = new ChatUserDto(user.getUserGender(), user.getUserNickname());
         return chatUserDto;
     }
 
@@ -88,12 +90,14 @@ public class ChatService {
         int end = start + size - 1;
         return chatRedistemplate.opsForList().range(roomId.toString(), start, end);
     }
+
     private List<ChatMessage> getDbMessages(Long roomId, int size, int page) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
         ChatRoom chatRoom = getChatRoom(roomId);
         Page<ChatMessage> byRoomIdOrderByCreatedAt = messageRepository.findByRoomOrderByCreatedAt(chatRoom, pageable);
         return byRoomIdOrderByCreatedAt.getContent();
     }
+
     private ChatRoom getChatRoom(Long roomId) {
         Optional<ChatRoom> byRoomId = roomRepository.findByRoomId(roomId);
         if (byRoomId.isPresent()) {
@@ -102,11 +106,12 @@ public class ChatService {
             throw new ChatRoomNotFoundException();
         }
     }
+
     private User getUser(Long userId) {
         Optional<User> byId = userRepository.findById(userId);
-        if(byId.isPresent()){
+        if (byId.isPresent()) {
             return byId.get();
-        }else {
+        } else {
             throw new UserNotFoundException();
         }
     }

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/application/MessageDtoConverter.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/application/MessageDtoConverter.java
@@ -19,11 +19,13 @@ public class MessageDtoConverter {
                 chatMessage.getIsRead()
         );
     }
+
     public static MessageDto fromRedisChatMessageDto(RedisChatMessageDto redisChatMessageDto) {
         Map<String, Object> map = redisChatMessageDto.toMap();
         MessageDto messageDto = convertToMessageDto(map);
         return messageDto;
     }
+
     private static MessageDto convertToMessageDto(Map<String, Object> redisMessage) {
         Long messageId = Long.valueOf(redisMessage.get("messageId").toString());
         Long userId = Long.valueOf(redisMessage.get("userId").toString());

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/application/MessageDtoConverter.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/application/MessageDtoConverter.java
@@ -14,9 +14,9 @@ public class MessageDtoConverter {
         return new MessageDto(
                 chatMessage.getMessageId(),
                 chatMessage.getContent(),
-                chatMessage.getSender().getUserId(),
+                chatMessage.getUser().getUserId(),
                 chatMessage.getCreatedAt(),
-                chatMessage.getChecked()
+                chatMessage.getIsRead()
         );
     }
     public static MessageDto fromRedisChatMessageDto(RedisChatMessageDto redisChatMessageDto) {

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/domain/ChatMessage.java
@@ -34,6 +34,7 @@ public class ChatMessage extends BaseTimeEntity {
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
     public ChatMessage(ChatRoom room, User user, boolean isRead, String content, LocalDateTime createdAt) {
         this.room = room;
         this.user = user;

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/domain/ChatMessage.java
@@ -19,26 +19,25 @@ public class ChatMessage extends BaseTimeEntity {
     private Long messageId;
 
     @ManyToOne
-    @JoinColumn(name = "sender_id", nullable = false)
-    private User sender;
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @ManyToOne
     @JoinColumn(name = "room_id", nullable = false)
     private ChatRoom room;
 
-    @Column(name = "checked", nullable = false)
-    private Boolean checked;
+    @Column(name = "isRead", nullable = false)
+    private Boolean isRead;
 
     @Column(name = "content", nullable = false)
     private String content;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
-
-    public ChatMessage(ChatRoom room, User sender, boolean checked, String content, LocalDateTime createdAt) {
+    public ChatMessage(ChatRoom room, User user, boolean isRead, String content, LocalDateTime createdAt) {
         this.room = room;
-        this.sender = sender;
-        this.checked = checked;
+        this.user = user;
+        this.isRead = isRead;
         this.content = content;
         this.createdAt = createdAt;
     }

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/dto/ChatPageableDto.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/dto/ChatPageableDto.java
@@ -1,0 +1,13 @@
+package com.moodmate.moodmatebe.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatPageableDto {
+    private int size;
+    private int page;
+    private int totalPages;
+    private int totalElements;
+}

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/dto/ChatResponseDto.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/dto/ChatResponseDto.java
@@ -1,0 +1,14 @@
+package com.moodmate.moodmatebe.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChatResponseDto {
+    private ChatUserDto user;
+    private ChatPageableDto pageable;
+    private List<MessageDto> chatList;
+}

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/dto/ChatUserDto.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/dto/ChatUserDto.java
@@ -1,0 +1,12 @@
+package com.moodmate.moodmatebe.domain.chat.dto;
+
+import com.moodmate.moodmatebe.domain.user.domain.Gender;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ChatUserDto {
+    private Gender gender;
+    private String nickname;
+}

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/dto/RedisChatMessageDto.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/dto/RedisChatMessageDto.java
@@ -24,6 +24,7 @@ public class RedisChatMessageDto {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     private LocalDateTime createdAt;
+
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
         map.put("messageId", messageId);

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/exception/ChatRoomNotFoundException.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/exception/ChatRoomNotFoundException.java
@@ -4,7 +4,7 @@ import com.moodmate.moodmatebe.global.error.ErrorCode;
 import com.moodmate.moodmatebe.global.error.exception.ServiceException;
 
 public class ChatRoomNotFoundException extends ServiceException {
-    public ChatRoomNotFoundException(){
+    public ChatRoomNotFoundException() {
         super(ErrorCode.CHAT_ROOM_NOT_FOUND);
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/redis/RedisSubscriber.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/redis/RedisSubscriber.java
@@ -31,7 +31,7 @@ public class RedisSubscriber implements MessageListener {
             simpMessageSendingOperations.convertAndSend("/sub/chat/" + roomMessage.getRoomId(), roomMessage);
         } catch (JsonParseException e) {
             throw new JsonParsingException();
-        }catch (JsonMappingException e){
+        } catch (JsonMappingException e) {
             throw new RuntimeException();
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/MessageRepository.java
@@ -8,5 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MessageRepository extends JpaRepository<ChatMessage, Long> {
     Page<ChatMessage> findByRoomOrderByCreatedAt(ChatRoom room, Pageable pageable);
+
     int countByRoom(ChatRoom room);
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/MessageRepository.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/MessageRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MessageRepository extends JpaRepository<ChatMessage, Long> {
     Page<ChatMessage> findByRoomOrderByCreatedAt(ChatRoom room, Pageable pageable);
+    int countByRoom(ChatRoom room);
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요
채팅내역조회 DTO에 `nickname`, `gender`, `totalPages`, `size`, `page` 를 추가하여 `ChatResponseDto`로 묶어 반환합니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

- Redis의 저장된 데이터를 JSON으로 역직렬화 하는 과정에서 오류가 발생하였습니다.
- Redis에 저장하는 부분의 `Jackson2JsonRedisSerializer`의 class를 `RedisChatMessageDto`로 수정하여 오류가 해결되었습니다.


<br>

## 3. 관련 스크린샷을 첨부해주세요.

DB => 데이터 총개수 12개

![image](https://github.com/Leets-Official/MoodMate-BE/assets/108799865/f0848880-35f8-498b-a9bd-a87cb8c4494d)

size 5, page 2일 경우
![image](https://github.com/Leets-Official/MoodMate-BE/assets/108799865/e7975f36-4d1a-4573-ac0a-ce1b35de39d6)

<br>

## 4. 완료 사항

- 채팅내역 조회 DTO 수정
- 역직렬화 오류 해결

<br>

## 5. 추가 사항
close #27
