### PR TITLE
[fix] #49 유저 메인페이지 api 수정

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
@@ -29,19 +29,33 @@ public class UserController {
 
     private final UserService userService;
     private final JwtProvider jwtProvider;
+//
+//    @Operation(summary = "메인 페이지 불러오기", description = "유저의 메인 페이지를 불러옵니다.")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200"),
+//            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+//            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+//            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+//    })
+//    @GetMapping("/main")
+//    public MainPageResponse getMainPage(@RequestHeader("Authorization") String authorizationHeader) {
+//        MainPageResponse mainPageResponse = userService.getMainPage(authorizationHeader);
+//
+//        return mainPageResponse;
+//    }
 
     @Operation(summary = "메인 페이지 불러오기", description = "유저의 메인 페이지를 불러옵니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MainPageResponse.class))),
+            @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/main")
-    public MainPageResponse getMainPage(@RequestHeader("Authorization") String authorizationHeader) {
+    public ResponseEntity<Map<String, MainPageResponse>> getMainPage(@RequestHeader("Authorization") String authorizationHeader) {
         MainPageResponse mainPageResponse = userService.getMainPage(authorizationHeader);
 
-        return mainPageResponse;
+        return new ResponseEntity<>(Map.of("mainPageResponse", mainPageResponse), HttpStatus.OK);
     }
 
     @Operation(summary = "회원 정보 설정", description = "회원 정보를 설정합니다.")

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
@@ -29,20 +29,6 @@ public class UserController {
 
     private final UserService userService;
     private final JwtProvider jwtProvider;
-//
-//    @Operation(summary = "메인 페이지 불러오기", description = "유저의 메인 페이지를 불러옵니다.")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200"),
-//            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-//            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-//            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-//    })
-//    @GetMapping("/main")
-//    public MainPageResponse getMainPage(@RequestHeader("Authorization") String authorizationHeader) {
-//        MainPageResponse mainPageResponse = userService.getMainPage(authorizationHeader);
-//
-//        return mainPageResponse;
-//    }
 
     @Operation(summary = "메인 페이지 불러오기", description = "유저의 메인 페이지를 불러옵니다.")
     @ApiResponses({

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
@@ -31,10 +31,17 @@ public class UserController {
     private final JwtProvider jwtProvider;
 
     @Operation(summary = "메인 페이지 불러오기", description = "유저의 메인 페이지를 불러옵니다.")
-    @ApiResponses({@ApiResponse(responseCode = "200")})
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = MainPageResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @GetMapping("/main")
-    public MainPageResponse getMainPage(@RequestHeader("Authorization") String token) {
-        return userService.getMainPage(token);
+    public MainPageResponse getMainPage(@RequestHeader("Authorization") String authorizationHeader) {
+        MainPageResponse mainPageResponse = userService.getMainPage(authorizationHeader);
+
+        return mainPageResponse;
     }
 
     @Operation(summary = "회원 정보 설정", description = "회원 정보를 설정합니다.")

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
@@ -28,24 +28,11 @@ public class UserController {
 
     private final UserService userService;
 
-//    @Operation(summary = "메인 페이지 불러오기")
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "200"),
-//    })
-//    @GetMapping("/main")
-//    public MainPageResponse getMainPage(@AuthenticationPrincipal AuthDetails authDetails) {
-//
-//        return userService.getMainPage();
-//    }
-
-    @Operation(summary = "메인 페이지 불러오기")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200")
-    })
+    @Operation(summary = "메인 페이지 불러오기", description = "유저의 메인 페이지를 불러옵니다.")
+    @ApiResponses({@ApiResponse(responseCode = "200")})
     @GetMapping("/main")
-    public MainPageResponse getMainPage() {
-        // TODO: 임시값
-        return userService.getMainPage(1L);
+    public MainPageResponse getMainPage(@RequestHeader("Authorization") String token) {
+        return userService.getMainPage(token);
     }
 
     @Operation(summary = "회원 정보 설정", description = "회원 정보를 설정합니다.")

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
@@ -30,26 +30,25 @@ public class UserService {
     private final Long ROOM_NOT_EXIST = -1L;
     private final JwtProvider jwtProvider;
 
-    public MainPageResponse getMainPage(String token) {
+    public MainPageResponse getMainPage(String authorizationHeader) {
 
         Long roomId = ROOM_NOT_EXIST;
         Boolean roomActive = false;
+        String token = jwtProvider.getTokenFromAuthorizationHeader(authorizationHeader);
         Long userId = jwtProvider.getUserIdFromToken(token);
 
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException());
+        Optional<User> user = userRepository.findById(userId);
         Optional<ChatRoom> chatRoom = roomRepository.findActiveChatRoomByUserId(userId);
 
-        Gender userGender = user.getUserGender();
-        Boolean userMatchActive = user.getUserMatchActive();
+        Gender userGender = user.get().getUserGender();
+        Boolean userMatchActive = user.get().getUserMatchActive();
 
         if (chatRoom.isPresent()) {
             roomId = chatRoom.get().getRoomId();
             roomActive = chatRoom.get().getRoomActive();
         }
 
-        MainPageResponse mainPageResponse = new MainPageResponse(userId, userGender, userMatchActive, roomId, roomActive);
-
-        return mainPageResponse;
+        return new MainPageResponse(userId, userGender, userMatchActive, roomId, roomActive);
     }
 
     @Transactional

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
@@ -26,20 +26,18 @@ public class UserService {
     private final Long ROOM_NOT_EXIST = -1L;
     private final JwtProvider jwtProvider;
 
-    public MainPageResponse getMainPage(Long userId) {
+    public MainPageResponse getMainPage(String token) {
 
-        Gender userGender = null;
-        Boolean userMatchActive = false;
         Long roomId = ROOM_NOT_EXIST;
         Boolean roomActive = false;
+        Long userId = jwtProvider.getUserIdFromToken(token);
 
-        Optional<User> user = userRepository.findById(userId);
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException());
         Optional<ChatRoom> chatRoom = roomRepository.findActiveChatRoomByUserId(userId);
 
-        if (user.isPresent()) {
-            userGender = user.get().getUserGender();
-            userMatchActive = user.get().getUserMatchActive();
-        }
+        Gender userGender = user.getUserGender();
+        Boolean userMatchActive = user.getUserMatchActive();
+
         if (chatRoom.isPresent()) {
             roomId = chatRoom.get().getRoomId();
             roomActive = chatRoom.get().getRoomActive();
@@ -58,8 +56,7 @@ public class UserService {
             }
 
             Long userId = jwtProvider.getUserIdFromToken(token);
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new UserNotFoundException());
+            User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException());
 
             user.setUserNickname(userInfoDto.getNickname());
             user.setUserKeywords(userInfoDto.getKeywords());

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/dto/MainPageResponse.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/dto/MainPageResponse.java
@@ -3,11 +3,9 @@ package com.moodmate.moodmatebe.domain.user.dto;
 import com.moodmate.moodmatebe.domain.user.domain.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
 public class MainPageResponse {
     private Long userId;
     private Gender userGender;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
메인페이지 호출 시 발생하는 404 에러를 수정했습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
영문모를 404에러를 3시간동안 붙잡아서 해결했습니다...
```
    public ResponseEntity<Map<String, MainPageResponse>> getMainPage(@RequestHeader("Authorization") String authorizationHeader) {
        MainPageResponse mainPageResponse = userService.getMainPage(authorizationHeader);

        return new ResponseEntity<>(Map.of("mainPageResponse", mainPageResponse), HttpStatus.OK);
    }
```
이런식으로 매핑해서 리턴해야 하는 걸 놓친 것 같습니다. 

ResponseBody는 아래와 같이 생겼습니다.
```
{
  "mainPageResponse": {
    "userId": 1,
    "userGender": "MALE",
    "userMatchActive": true,
    "roomId": -1,
    "roomActive": false
  }
}
```
<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/Leets-Official/MoodMate-BE/assets/84257033/4be3cf5d-9c2b-4b34-921e-8e089a66f1e9)

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
