### PR TITLE
[feat] #57 상대무디 상세조회 api 구현

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/RoomRepository.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/RoomRepository.java
@@ -13,5 +13,5 @@ public interface RoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("SELECT cr FROM chat_room cr WHERE (cr.user1.userId = :userId OR cr.user2.userId = :userId) AND cr.roomActive = TRUE")
     Optional<ChatRoom> findActiveChatRoomByUserId(@Param("userId") Long userId);
 
-    Optional<ChatRoom> findByUser1IdOrUser2Id(Long user1Id, Long user2Id);
+    Optional<ChatRoom> findByUser1UserIdOrUser2UserId(Long user1Id, Long user2Id);
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/RoomRepository.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/RoomRepository.java
@@ -13,5 +13,4 @@ public interface RoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("SELECT cr FROM chat_room cr WHERE (cr.user1.userId = :userId OR cr.user2.userId = :userId) AND cr.roomActive = TRUE")
     Optional<ChatRoom> findActiveChatRoomByUserId(@Param("userId") Long userId);
 
-    Optional<ChatRoom> findByUser1UserIdOrUser2UserId(Long user1Id, Long user2Id);
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/RoomRepository.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/repository/RoomRepository.java
@@ -4,10 +4,14 @@ import com.moodmate.moodmatebe.domain.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
 public interface RoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByRoomId(Long roomId);
+
     @Query("SELECT cr FROM chat_room cr WHERE (cr.user1.userId = :userId OR cr.user2.userId = :userId) AND cr.roomActive = TRUE")
     Optional<ChatRoom> findActiveChatRoomByUserId(@Param("userId") Long userId);
+
+    Optional<ChatRoom> findByUser1IdOrUser2Id(Long user1Id, Long user2Id);
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
@@ -4,6 +4,7 @@ import com.moodmate.moodmatebe.domain.user.application.UserService;
 import com.moodmate.moodmatebe.domain.user.domain.Prefer;
 import com.moodmate.moodmatebe.domain.user.domain.User;
 import com.moodmate.moodmatebe.domain.user.dto.MainPageResponse;
+import com.moodmate.moodmatebe.domain.user.dto.PartnerResponse;
 import com.moodmate.moodmatebe.domain.user.dto.PreferInfoRequest;
 import com.moodmate.moodmatebe.domain.user.dto.UserInfoRequest;
 import com.moodmate.moodmatebe.global.error.ErrorResponse;
@@ -117,5 +118,18 @@ public class UserController {
     public ResponseEntity<Map<String, String>> refreshAccessToken(@CookieValue("refreshToken") String tokenInput) {
         Map<String, String> newTokens = userService.refreshAccessToken(tokenInput);
         return new ResponseEntity<>(newTokens, HttpStatus.OK);
+    }
+
+    @Operation(summary = "상대무디 정보 조회", description = "현재 채팅 중인 상대방의 정보를 상세조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200"),
+        @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/partner")
+    public ResponseEntity<Map<String, PartnerResponse>> getPartnerInfo(@RequestHeader("Authorization") String authorizationHeader){
+        PartnerResponse partnerInfo = userService.getPartnerInfo(authorizationHeader);
+        return new ResponseEntity<>(Map.of("PartnerResponse",partnerInfo),HttpStatus.OK);
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
@@ -1,11 +1,13 @@
 package com.moodmate.moodmatebe.domain.user.application;
 
 import com.moodmate.moodmatebe.domain.chat.domain.ChatRoom;
+import com.moodmate.moodmatebe.domain.chat.exception.ChatRoomNotFoundException;
 import com.moodmate.moodmatebe.domain.chat.repository.RoomRepository;
 import com.moodmate.moodmatebe.domain.user.domain.Gender;
 import com.moodmate.moodmatebe.domain.user.domain.Prefer;
 import com.moodmate.moodmatebe.domain.user.domain.User;
 import com.moodmate.moodmatebe.domain.user.dto.MainPageResponse;
+import com.moodmate.moodmatebe.domain.user.dto.PartnerResponse;
 import com.moodmate.moodmatebe.domain.user.dto.PreferInfoRequest;
 import com.moodmate.moodmatebe.domain.user.dto.UserInfoRequest;
 import com.moodmate.moodmatebe.domain.user.exception.InvalidInputValueException;
@@ -34,7 +36,7 @@ public class UserService {
     private final Long ROOM_NOT_EXIST = -1L;
     private final JwtProvider jwtProvider;
 
-    public Prefer setUserPrefer(String authorizationHeader, PreferInfoRequest preferInfoRequest){
+    public Prefer setUserPrefer(String authorizationHeader, PreferInfoRequest preferInfoRequest) {
 
         String token = jwtProvider.getTokenFromAuthorizationHeader(authorizationHeader);
         Long userId = jwtProvider.getUserIdFromToken(token);
@@ -51,7 +53,7 @@ public class UserService {
         return preferRepository.save(prefer);
     }
 
-    public User changeUserMatchActive(String authorizationHeader){
+    public User changeUserMatchActive(String authorizationHeader) {
 
         String token = jwtProvider.getTokenFromAuthorizationHeader(authorizationHeader);
         Long userId = jwtProvider.getUserIdFromToken(token);
@@ -130,5 +132,27 @@ public class UserService {
         } catch (Exception e) {
             throw new ServiceException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    public PartnerResponse getPartnerInfo(String authorizationHeader) {
+        String token = jwtProvider.getTokenFromAuthorizationHeader(authorizationHeader);
+        Long userId = jwtProvider.getUserIdFromToken(token);
+
+        Optional<ChatRoom> byUser1IdOrUser2Id = roomRepository.findByUser1UserIdOrUser2UserId(userId, userId);
+        ChatRoom chatRoom = byUser1IdOrUser2Id.orElseThrow(() -> new ChatRoomNotFoundException());
+        Long otherUserId = (userId.equals(chatRoom.getUser1().getUserId())) ? chatRoom.getUser2().getUserId() : chatRoom.getUser1().getUserId();
+
+        User otherUser = userRepository.findById(otherUserId).orElseThrow(() -> new UserNotFoundException());
+
+        Optional<String> preferMoodByUserId = preferRepository.findPreferMoodByUserId(otherUserId);
+
+        return new PartnerResponse(
+                otherUser.getUserNickname(),
+                otherUser.getUserKeywords(),
+                otherUser.getUserGender(),
+                otherUser.getUserDepartment(),
+                otherUser.getYear(),
+                preferMoodByUserId.get()
+        );
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
@@ -149,8 +149,8 @@ public class UserService {
         String token = jwtProvider.getTokenFromAuthorizationHeader(authorizationHeader);
         Long userId = jwtProvider.getUserIdFromToken(token);
 
-        Optional<ChatRoom> byUser1IdOrUser2Id = roomRepository.findByUser1UserIdOrUser2UserId(userId, userId);
-        ChatRoom chatRoom = byUser1IdOrUser2Id.orElseThrow(() -> new ChatRoomNotFoundException());
+        Optional<ChatRoom> activeChatRoomByUserId = roomRepository.findActiveChatRoomByUserId(userId);
+        ChatRoom chatRoom = activeChatRoomByUserId.orElseThrow(() -> new ChatRoomNotFoundException());
         Long otherUserId = (userId.equals(chatRoom.getUser1().getUserId())) ? chatRoom.getUser2().getUserId() : chatRoom.getUser1().getUserId();
 
         User otherUser = userRepository.findById(otherUserId).orElseThrow(() -> new UserNotFoundException());

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/dto/PartnerResponse.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/dto/PartnerResponse.java
@@ -1,0 +1,19 @@
+package com.moodmate.moodmatebe.domain.user.dto;
+
+import com.moodmate.moodmatebe.domain.user.domain.Keyword;
+import com.nimbusds.openid.connect.sdk.claims.Gender;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PartnerResponse {
+    private String nickname;
+    private List<Keyword> keywords;
+    private Gender gender;
+    private String department;
+    private Integer year;
+    private String preferMood;
+}

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/dto/PartnerResponse.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/dto/PartnerResponse.java
@@ -1,10 +1,9 @@
 package com.moodmate.moodmatebe.domain.user.dto;
 
+import com.moodmate.moodmatebe.domain.user.domain.Gender;
 import com.moodmate.moodmatebe.domain.user.domain.Keyword;
-import com.nimbusds.openid.connect.sdk.claims.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/repository/PreferRepository.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/repository/PreferRepository.java
@@ -2,11 +2,12 @@ package com.moodmate.moodmatebe.domain.user.repository;
 
 import com.moodmate.moodmatebe.domain.user.domain.Prefer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface PreferRepository extends JpaRepository<Prefer, Long> {
-    Optional<Prefer> findById(Long preferId);
-    List<Prefer> findAll();
+    @Query("SELECT p.preferMood FROM prefer p WHERE p.user.userId = :userId")
+    Optional<String> findPreferMoodByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

- 채팅중이 유저의 상대방에 대한 정보를 조회합니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

현재 지원이(userid =2)와 지원이2(userid = 3)가 같은 채팅방에 있습니다.
지원이(userid =2)가 상대인 지원이2(userid = 3)의 정보를 조회한 경우입니다.

![image](https://github.com/Leets-Official/MoodMate-BE/assets/108799865/f7eb8262-e0d8-46be-a920-1b69e15c3854)

![image](https://github.com/Leets-Official/MoodMate-BE/assets/108799865/f98399c6-70e3-4f99-8a41-a7a5adb16694)

![image](https://github.com/Leets-Official/MoodMate-BE/assets/108799865/b2a6a6a8-ed35-4c9e-807f-2becb7822255)


<br>

## 4. 완료 사항
상대무디 상세조회 API

<br>

## 5. 추가 사항
close #34
