### PR TITLE
[fix] #88 개인 정보 수정 동일 학과 가능 추가

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
@@ -183,6 +183,7 @@ public class UserService {
         user.setUserKeywords(updateUserRequest.getUserKeywords());
         prefer.setPreferYearMin(updateUserRequest.getPreferYearMin());
         prefer.setPreferYearMax(updateUserRequest.getPreferYearMax());
+        prefer.setPreferDepartmentPossible(updateUserRequest.isPreferDepartmentPossible());
         prefer.setPreferMood(updateUserRequest.getPreferMood());
 
         userRepository.save(user);

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/dto/UpdateUserRequest.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/dto/UpdateUserRequest.java
@@ -12,5 +12,6 @@ public class UpdateUserRequest {
     private List<Keyword> userKeywords;
     private int preferYearMin;
     private int preferYearMax;
+    private boolean preferDepartmentPossible;
     private String preferMood;
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 개인 정보 수정 api에 동일 학과 가능 추가
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
요청값
```json
{
    "userKeywords": ["인기짱", "반려인", "배려왕"],
    "preferYearMin": 2002,
    "preferYearMax": 1998, 
    "preferDepartmentPossible": true,
    "preferMood": "유쾌한"
}
```

응답값
```json
{
    "updateResponse": {
        "userKeywords": [
            "인기짱",
            "반려인",
            "배려왕"
        ],
        "preferYearMin": 2002,
        "preferYearMax": 1998,
        "preferDepartmentPossible": true,
        "preferMood": "유쾌한"
    }
}
```
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1191" alt="img1" src="https://github.com/Leets-Official/MoodMate-BE/assets/70849467/1ab1f306-7706-4134-ac67-54ea8af03642">
<img width="1191" alt="img2" src="https://github.com/Leets-Official/MoodMate-BE/assets/70849467/ad1a36f8-4aee-4902-9696-e955adf224a1">

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
close #87 