### PR TITLE
[feat] #100 local 환경에서의 로그레벨 설정, 중복 의존성 삭제, H2 DB 접근 권한 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,9 +62,6 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
     implementation 'javax.servlet:javax.servlet-api:4.0.1'
-
-    // Slf4j Logging
-    implementation 'ch.qos.logback:logback-classic:1.2.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/moodmate/moodmatebe/global/security/WebSecurityConfig.java
+++ b/src/main/java/com/moodmate/moodmatebe/global/security/WebSecurityConfig.java
@@ -44,10 +44,13 @@ public class WebSecurityConfig {
                 .and()
                 .exceptionHandling()
                 .and()
+                .headers().frameOptions().disable() // x-frame-options을 비활성화, spring security에서 clickjacking 공격을 막기위해 사용하기에, 서비스를 배포할 때 해당 줄 삭제
+                .and()
                 .authorizeHttpRequests()
                 .requestMatchers(CorsUtils::isCorsRequest).permitAll()
 
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
+                .requestMatchers("/h2-console/**").permitAll()
                 .requestMatchers("/**").permitAll()
 
                 .anyRequest().authenticated()

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -50,4 +50,4 @@ social-login:
 
 logging:
   level:
-    root: info
+    root: trace

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -46,3 +46,7 @@ cors:
 
 social-login:
   redirect: ENC(W4b92hK1VGe6ronN9gmeVVoyCvRoGTWPlwVhq12WBWPi4lyg+Bxwu0oVn9KCKQZU)
+
+logging:
+  level:
+    root: trace

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,23 +1,24 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/moodmate
+    url: jdbc:h2:~/moodmate
     username: root
-    password:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    password: 1234
+    driver-class-name: org.h2.Driver
   jpa:
     show-sql: true
     hibernate:
       ddl-auto: update
-    database: mysql
+    database: h2
     properties:
       hibernate:
         format_sql: true
         show_sql: false
         use_sql_comments: true
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.H2Dialect
   h2:
     console:
-      enabled: false
+      enabled: true
+      path: /h2-console
   data:
     redis:
       host: localhost
@@ -49,4 +50,4 @@ social-login:
 
 logging:
   level:
-    root: trace
+    root: info


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- local 환경에서 로그레벨을 trace로 관리하기 위해 해당 기능을 yml 파일에 추가했습니다.
- logback-classic 의존성이 spring-starter-web 하위에 포함되어 있기 때문에 삭제했습니다.
- local 환경에서 h2 DB를 이용하기 위해 sql 설정을 h2로 변경했습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- h2 설정을 마치고 h2 DB에 접속했으나, 'localhost 연결을 거부했습니다' 라는 알림이 뜨고 해당 DB를 이용하지 못했습니다.
- 위 문제를 2가지 옵션을 추가해 해결했습니다.
    - requestMatchers 메서드에 /h2-console/** 추가
    - x-frame-options 비활성화

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/Leets-Official/MoodMate-BE/assets/125895298/9ad92271-8a6f-4129-bfca-309176a631bb)
- 'localhost 연결을 거부했습니다' 라는 알림이 뜨고 h2 DB를 이용하지 못함.

<img width="1559" alt="image" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/9decb7bd-0e11-4a11-bb12-799733aaa759">
- 2가지 옵션을 추가하여 문제 해결 

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
- x-frame-option은 spring security에서 clickjacking 공격을 막기위해 사용하기에, 서비스를 배포할 때는 해당 줄을 삭제해야 할 것 같습니다.
close #98 