### PR TITLE
[fix] #112 @Transactional 어노테이션 적용으로 데이터베이스 세션을 활성 상태로 유지

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/matching/application/MatchingService.java
@@ -10,6 +10,7 @@ import com.moodmate.moodmatebe.domain.user.domain.Gender;
 import com.moodmate.moodmatebe.domain.user.domain.Prefer;
 import com.moodmate.moodmatebe.domain.user.repository.PreferRepository;
 import com.moodmate.moodmatebe.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -35,6 +36,7 @@ public class MatchingService {
         this.whoMeetRepository = whoMeetRepository;
     }
 
+    @Transactional
     public void match() {
         List<Prefer> activeMatchTrue = preferRepository.findByUserMatchActiveAndGenderTrue(Gender.MALE);
         activeMatchTrue.addAll(preferRepository.findByUserMatchActiveAndGenderTrue(Gender.FEMALE));
@@ -52,6 +54,7 @@ public class MatchingService {
         }
     }
 
+    @Transactional
     public void grouping() {
         Map<String, Man> m = convertListToMap(men);
         Map<String, Woman> w = convertListToMap(women);


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- LazyInitializationException을 해결하기 위해 메서드를 @Transactional로 감싸 트랜잭션이 메서드 실행 동안 유지되도록 했습니다.
- match 메서드 뿐만 아니라 grouping 메서드도 지연 로딩이 필요한 데이터에 접근할 가능성이 있기에 두 메서드에 모두 @Transactional 어노테이션을 적용했습니다.


<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 지연 로딩이 필요한 엔티티의 속성에 접근하여서, LazyInitializationException가 발생하였습니다.

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1009" alt="image" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/182b4ef8-3d46-454d-96c5-67fefed3cac7">

- LazyInitializationException없이 제대로 매칭이 실행이 되는 모습
<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
closes #111 
