### PR TITLE
[fix] #119 리스트 shuffle을 했음에도 같은 무드 그룹 내에서 남녀의 각 리스트의 key 순서가 고정되는 점 해결

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/matching/application/MatchingService.java
@@ -164,10 +164,10 @@ public class MatchingService {
     }
 
     private static <T extends Person> Map<String, Map<String, T>> groupByMood(Map<String, T> persons) {
-        Map<String, Map<String, T>> groups = new HashMap<>();
+        Map<String, Map<String, T>> groups = new LinkedHashMap<>();
         for (T person : persons.values()) {
             if (!groups.containsKey(person.getMood())) {
-                groups.put(person.getMood(), new HashMap<>());
+                groups.put(person.getMood(), new LinkedHashMap<>());
             }
             groups.get(person.getMood()).put(person.getName(), person);
         }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 리스트 shuffle을 했음에도 무드 그룹 내에서 남녀의 각 리스트의 key값 순서가 고정되어서 매칭이 되지 않았던 사람이 또 다시 매칭이 되지 않아 코드를 변경했습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- HashMap을 사용하면 항상 동일한 순서로 person 객체가 고정되었습니다.
- 따라서 매칭이 되지 않았던 사람이 또 다시 매칭이 되지 않을 확률이 높아 로직을 수정해야 했습니다.


### 테스트 데이터

남자 150, 여 149

```plain
# 이색적인 무드 남 : 33, 여 : 35 -> 33(총 매칭 수)
# 풍부한 무드 남 : 51, 여 : 44 -> 44(총 매칭 수)
# 유쾌한 무드 남 : 12, 여 : 18 -> 12(총 매칭 수)
# 활기찬 무드 남 : 54, 여 : 52 -> 52(총 매칭 수)
```

### 첫번째 시도

```plain
// 활기찬 
52명 성공

// 풍부한
44명 성공

// 유쾌한 
여131 - null
여122 - null
여143 - null
여110 - null
여113 - null
여134 - null

// 이색적인
여124 - null
여145 - null
```

### 두번째 시도

```plain
// 활기찬 
52명 성공

// 풍부한
44명 성공

// 유쾌한 
여140 - null 
여122 - null
여143 - null
여110 - null
여113 - null
여134 - null

// 이색적인
여124 - null 
여145 - null
```

### 세번째 시도

```plain
// 활기찬 
52명 성공

// 풍부한
44명 성공

// 유쾌한 
여140 - null 
여131 - null 
여143 - null 
여110 - null
여113 - null
여134 - null

// 이색적인
여19 - null 
여145 - null 
```

### 여자 1명 추가(남 150, 여 150)

```plain
# 이색적인 무드 남 : 33, 여 : 35 -> 33
# 풍부한 무드 남 : 51, 여 : 44 -> 44
# 유쾌한 무드 남 : 12, 여 : 19 -> 12 // 유쾌한에 1명 추가
# 활기찬 무드 남 : 54, 여 : 52 -> 52
```

### 첫번째 시도

```plain
// 활기찬 
52명 성공

// 풍부한
44명 성공

// 유쾌한 
여122 - null
여131 - null 
여143 - null 
여110 - null
여113 - null
여134 - null
여150 - null

// 이색적인
여100 - null 
여145 - null 
```
<br>

- 약간의 커플 매칭 변동은 who_meet 테이블에 의해 만났던 사람을 가장 후순위로 배치했기 때문이라고 판단됩니다.
- 결국 중요한 점은 매칭이 되지 않은 사람은 다시 매칭이 되지 않을 확률이 높다는 점이 테스트를 통해 확인되었기에 로직을 수정해야 합니다.


## 3. 관련 스크린샷을 첨부해주세요.
<img width="1724" alt="image" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/482b64b6-79d7-461c-8cdc-08301f989905">

- 위 사진은 groupByMood 메서드를 거치고 나온 menGroups, womenGroups 리스트에 대해 출력을 나타내며, 여러 번 프로그램을 실행해도 그룹 내에서 person 객체가 해당 사진에 나온 순서로 고정되어 출력됩니다.
- HashMap은 키의 해시값에 따라 데이터를 저장하므로 삽입 순서에 상관없이 항상 동일한 순서로 데이터를 처리합니다. 이로 인해 같은 데이터 세트에 대해 HashMap을 사용하면 항상 동일한 순서로 person 객체가 고정되었던 것입니다.

<br>

<img width="1723" alt="image" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/cd6831b0-3503-48b2-93ee-16995a7f80db">
<img width="1724" alt="image" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/13848f66-e3ac-4832-832f-f54a2a064b36">

- 첫번째 사진은 처음 프로그램을 실행, 두번째 사진은 다시 한번 더 프로그램을 실행했을 때 groupByMood 메서드를 거치고 나온 menGroups, womenGroups 리스트에 대한 출력을 나타냅니다.
- shuffle 된 순서를 그대로 가져와 그룹별로 분류하는 모습을 볼 수 있습니다. 
- ex. 남1의 무드 "이색적인", 남2의 무드 "유쾌한", 남3의 무드 "이색적인", 남4의 무드 "풍부한"라고 할때 shuffle 리스트 순서 [남1, 남3, 남4, 남2]라면, 출력은 다음과 같습니다. 

> 무드 : 이색적인
> 남1 남3
> 무드 : 풍부한
> 남4
> 무드 : 유쾌한
> 남2

<br>

## 4. 완료 사항
- Map<String, Map<String, T>> groups = new HashMap<>()을 Map<String, Map<String, T>> groups = new LinkedHashMap<>()로 수정
- groups.put(person.getMood(), new HashMap<>())을 groups.put(person.getMood(), new LinkedHashMap<>())으로 수정

<br>

## 5. 추가 사항
closes #118 