### PR TITLE
[fix] #146 menGroup 또는 womenGroup이 null이라도 계속해서 진행되도록 수정

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/matching/application/MatchingService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/matching/application/MatchingService.java
@@ -62,7 +62,16 @@ public class MatchingService {
         Map<String, Map<String, Woman>> womenGroups = groupByMood(convertListToMap(women));
 
         for (String mood : menGroups.keySet()) {
-            matchGroupsByMood(mood, menGroups.get(mood), womenGroups.get(mood));
+            Map<String, Man> menGroup = menGroups.get(mood);
+            Map<String, Woman> womenGroup = womenGroups.get(mood);
+
+            // null일 시, 다음 그룹으로 넘어가도록 함
+            if (menGroup == null || womenGroup == null || menGroup.isEmpty() || womenGroup.isEmpty()) {
+                log.info("{} 그룹에 유효한 매칭 대상이 없습니다.", mood);
+                continue;
+            }
+
+            matchGroupsByMood(mood, menGroup, womenGroup);
         }
     }
 


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 서비스의 유저 수가 200명이 넘어갔기에, 각 그룹 내에서 user_match_active가 true인 사람이 0이 될 수도 있다는 사실을 간과했습니다. 따라서 확장성을 고려하여 menGroup과 womenGroup이 null일 경우라도 매칭 프로그램이 에러없이 수행될 수 있도록 코드를 변경하였습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 프로덕션 서버에서 '잔잔한' 무드를 가지면서 user_match_active가 true인 womenGroup이 존재하지 않아 NullPointerException이 발생하였습니다.

<br>

## 3. 관련 스크린샷을 첨부해주세요.
### 프로덕션 서버에서 사용하는 DB를 로컬로 백업 후 매칭 활성화가 true이며 "잔잔한"무드의 여성분들의 수를 COUNT
![image](https://github.com/Leets-Official/MoodMate-BE/assets/125895298/f9e0dfa1-5aad-4901-b5a3-63517721fa84)
- 조건에 해당하는 여성의 수가 0명임을 확인할 수 있습니다.

### 프로덕션 서버에서 사용하는 DB를 로컬로 백업 후 매칭 활성화가 false이며 "잔잔한"무드의 여성분들의 수를 COUNT
![image](https://github.com/Leets-Official/MoodMate-BE/assets/125895298/53690ac9-1ccd-4ccd-b5b7-8c208f6c4d3b)
- 조건에 해당하는 여성은 1명이였으며, user_match_active가 false였습니다.
- 이를 통해, 잔잔한 무드에 존재하는 여성이 1명이나 그 마저도 매칭 비활성화 상태이였기에 womenGroup이 null이 되게 된 것입니다.

### 프로덕션 서버에서 사용하는 DB를 그대로 백업 후 로컬 서버에서 테스트
![image](https://github.com/Leets-Official/MoodMate-BE/assets/125895298/a15fc532-5220-4346-9780-5eece5dc8a3c)
- 실제로도 잔잔한 무드의 womenGroup이 null이여서 NullPointerException이 발생했음을 더블 체크 하였습니다.

### 예외 처리 후 로컬 서버에서 테스트
![image](https://github.com/Leets-Official/MoodMate-BE/assets/125895298/c66f459d-84fa-4eb2-bb07-b3eabe7ae7ab)
- 예외 처리를 해줌으로서 womenGroup이 null 혹은 menGroup이 null이라도, 매칭이 문제없이 수행될 수 있게 되었습니다.

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
- closes #145 