### PR TITLE
[fix] #150 같은 무드 같은 성별일 때 닉네임이 중복되는 경우 닉네임을 변경하지 못하도록 제한하고, 중복이 되지 않는 걸 확인한 뒤 닉네임 변경을 할 수 있는 api 생성 

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/MyPageController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/MyPageController.java
@@ -2,6 +2,10 @@ package com.moodmate.moodmatebe.domain.user.api;
 
 import com.moodmate.moodmatebe.domain.user.application.MyPageService;
 import com.moodmate.moodmatebe.domain.user.dto.MyPageResponse;
+import com.moodmate.moodmatebe.domain.user.dto.NicknameCheckRequest;
+import com.moodmate.moodmatebe.domain.user.dto.NicknameCheckResponse;
+import com.moodmate.moodmatebe.domain.user.dto.NicknameModifyRequest;
+import com.moodmate.moodmatebe.domain.user.dto.NicknameModifyResponse;
 import com.moodmate.moodmatebe.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -51,5 +55,33 @@ public class MyPageController {
 
 
         return new ResponseEntity<>(Map.of("myPageResponse", response), HttpStatus.OK);
+    }
+
+    @Operation(summary = "닉네임 중복 검사", description = "같은 무드와 같은 성별에서 닉네임 중복 여부를 검사합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/nickname/check")
+    public ResponseEntity<NicknameCheckResponse> checkDuplicateNickname(@RequestBody NicknameCheckRequest nicknameCheckRequest) {
+        NicknameCheckResponse response = myPageService.checkDuplicateNickname(nicknameCheckRequest);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @Operation(summary = "닉네임 변경", description = "닉네임을 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/nickname/change")
+    public ResponseEntity<NicknameModifyResponse> changeNickname(@RequestBody NicknameModifyRequest nicknameModifyRequest) {
+        NicknameModifyResponse response = myPageService.changeNickname(nicknameModifyRequest);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/MyPageController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/MyPageController.java
@@ -79,7 +79,7 @@ public class MyPageController {
             @ApiResponse(responseCode = "404", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @PostMapping("/nickname/change")
+    @PutMapping("/nickname/change")
     public ResponseEntity<NicknameModifyResponse> changeNickname(@RequestBody NicknameModifyRequest nicknameModifyRequest) {
         NicknameModifyResponse response = myPageService.changeNickname(nicknameModifyRequest);
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/MyPageService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/MyPageService.java
@@ -3,6 +3,10 @@ package com.moodmate.moodmatebe.domain.user.application;
 import com.moodmate.moodmatebe.domain.user.domain.Prefer;
 import com.moodmate.moodmatebe.domain.user.domain.User;
 import com.moodmate.moodmatebe.domain.user.dto.MyPageResponse;
+import com.moodmate.moodmatebe.domain.user.dto.NicknameCheckRequest;
+import com.moodmate.moodmatebe.domain.user.dto.NicknameCheckResponse;
+import com.moodmate.moodmatebe.domain.user.dto.NicknameModifyRequest;
+import com.moodmate.moodmatebe.domain.user.dto.NicknameModifyResponse;
 import com.moodmate.moodmatebe.domain.user.exception.PreferNotFoundException;
 import com.moodmate.moodmatebe.domain.user.exception.UserNotFoundException;
 import com.moodmate.moodmatebe.domain.user.repository.PreferRepository;
@@ -10,6 +14,9 @@ import com.moodmate.moodmatebe.domain.user.repository.UserRepository;
 import com.moodmate.moodmatebe.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -81,4 +88,23 @@ public class MyPageService {
                 .build();
     }
 
+    @Transactional
+    public NicknameCheckResponse checkDuplicateNickname(NicknameCheckRequest nicknameCheckRequest) {
+        List<User> usersWithSameNickname = userRepository.findByUserNicknameAndUserGenderAndUserPreferMood(
+                nicknameCheckRequest.userNickname(), nicknameCheckRequest.userGender(), nicknameCheckRequest.preferMood());
+        if (!usersWithSameNickname.isEmpty()) {
+            return new NicknameCheckResponse(true, "닉네임이 중복되었습니다.");
+        }
+        return new NicknameCheckResponse(false, "닉네임이 중복되지 않았습니다.");
+    }
+
+    @Transactional
+    public NicknameModifyResponse changeNickname(NicknameModifyRequest nicknameModifyRequest) {
+        User user = userRepository.findById(nicknameModifyRequest.userId())
+                .orElseThrow(UserNotFoundException::new);
+        user.setUserNickname(nicknameModifyRequest.newNickname());
+        userRepository.save(user);
+
+        return new NicknameModifyResponse(false, "닉네임이 성공적으로 변경되었습니다.");
+    }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameCheckRequest.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameCheckRequest.java
@@ -1,0 +1,10 @@
+package com.moodmate.moodmatebe.domain.user.dto;
+
+import com.moodmate.moodmatebe.domain.user.domain.Gender;
+
+public record NicknameCheckRequest(
+        String userNickname,
+        String preferMood,
+        Gender userGender
+) {
+}

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameCheckResponse.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameCheckResponse.java
@@ -1,0 +1,7 @@
+package com.moodmate.moodmatebe.domain.user.dto;
+
+public record NicknameCheckResponse(
+        boolean isDuplicate,
+        String message
+) {
+}

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameModifyRequest.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameModifyRequest.java
@@ -1,0 +1,7 @@
+package com.moodmate.moodmatebe.domain.user.dto;
+
+public record NicknameModifyRequest(
+        Long userId,
+        String newNickname
+) {
+}

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameModifyResponse.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameModifyResponse.java
@@ -1,0 +1,7 @@
+package com.moodmate.moodmatebe.domain.user.dto;
+
+public record NicknameModifyResponse(
+        boolean isDuplicate,
+        String message
+) {
+}

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/repository/UserRepository.java
@@ -1,11 +1,14 @@
 package com.moodmate.moodmatebe.domain.user.repository;
 
 import com.moodmate.moodmatebe.domain.user.domain.User;
+import com.moodmate.moodmatebe.domain.user.domain.Gender;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long userId);
     Optional<User> findByUserEmail(String userEmail);
+    List<User> findByUserNicknameAndUserGenderAndUserPreferMood(String nickname, Gender gender, String mood);
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/repository/UserRepository.java
@@ -1,8 +1,10 @@
 package com.moodmate.moodmatebe.domain.user.repository;
 
-import com.moodmate.moodmatebe.domain.user.domain.User;
 import com.moodmate.moodmatebe.domain.user.domain.Gender;
+import com.moodmate.moodmatebe.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,5 +12,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long userId);
     Optional<User> findByUserEmail(String userEmail);
-    List<User> findByUserNicknameAndUserGenderAndUserPreferMood(String nickname, Gender gender, String mood);
+
+    @Query("SELECT u FROM User u JOIN u.prefer p WHERE u.userNickname = :nickname AND u.userGender = :gender AND p.preferMood = :mood")
+    List<User> findByUserNicknameAndUserGenderAndUserPreferMood(@Param("nickname") String userNickname, @Param("gender") Gender userGender, @Param("mood") String userPreferMood);
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 다른 무드 다른 성별일때 닉넴 중복 - OK
- 다른 무드 같은 성별일때 닉넴 중복 - OK
- 같은 무드 다른 성별일때 닉넴 중복 - OK
- 같은 무드 같은 성별일때 닉넴 중복 - 한명만 매칭에 참여할 수 있음

**4번째 문제를 매칭 되었던 사람을 가장 후순위로 배치할 때 key값을 닉네임에서 유저아이디로 수정하면서 발견하게 되었습니다.**

<br>


1. api를 제작해 같은 무드 내에 같은 성별일 때, 닉네임 변경을 못하도록 막는 방법
2. 같은 무드 같은 성별일 때, 닉네임이 중복이어도 매칭을 돌아갈 수 있도록 하는 방법

**따라서 다음과 같은 두 가지 방법에 대해 고민을 해보았고, 후자의 방법대로 진행하다가 매칭 로직을 대폭 수정해야 했기에 전자의 방법으로 진행하게 되었습니다.**
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 처음에는 단일 api로 닉네임 중복체크, 닉네임 수정을 한번에 하려고 했으나, 그러면 사용자는 수정된 닉네임을 입력해 요청을 보내야지만 닉네임이 중복인 지 알 수 있었습니다. 이 방법은 사용자에게 불편함을 주는 방법이라고 생각이 들었고 닉네임 중복 체크 api, 닉네임 수정 api로 분리하여  api를 제작하게 되었습니다.


<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="571" alt="m1" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/9acec4aa-caf5-411c-8db2-4a8ad0efa2de">

<img width="1032" alt="m2" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/b21a7e46-42e5-474e-97cb-b8c6dbb0e173">

- 숲은 user_id가 1입니다.

<img width="794" alt="m3" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/9bbca1eb-fb79-4e21-b4be-5f8e47801b6b">

```json
{
    "isDuplicate": true,
    "message": "닉네임이 중복되었습니다."
}
```

<img width="797" alt="m4" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/60f957ef-b33e-42fc-91be-1454c9af7c41">


```json
{
    "isDuplicate": false,
    "message": "닉네임이 중복되지 않았습니다."
}
```

<img width="794" alt="m5" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/dba45bd1-e9d7-4a92-89cb-fe4345006b2a">


```json
{
    "isDuplicate": false,
    "message": "닉네임이 중복되지 않았습니다."
}
```

<img width="796" alt="m6" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/fd4ecc9d-5cd2-4962-bd88-24599864a5e8">

```json
{
    "isDuplicate": false,
    "message": "닉네임이 중복되지 않았습니다."
}
```

- 그림을 보면 같은 무드, 같은 성별 일 때 닉네임이 중복일 경우에만 중복이 되는 것을 볼 수 있습니다.

---

<img width="796" alt="image" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/fec0fbdd-118f-4dfa-b780-5de8cfb21fd0">



```json
{
    "isDuplicate": false,
    "message": "닉네임이 성공적으로 변경되었습니다."
}
```
- 닉네임 수정 api는 userId와 변경하고자 하는 닉네임(newNickname)을 보내게 됩니다. 
- **단, 필수 조건은 중복 체크가 진행이 된 후에 닉네임 수정 api로 요청을 보낼 수 있습니다.** 
    - **따라서 프론트엔드 측에서, 중복 체크 버튼을 눌러 닉네임 중복을 확인하고 중복 닉네임이 아닌 경우에 닉네임 변경 버튼을 활성화 시켜 안전하게 닉네임을 변경할 수 있도록 할 예정입니다.**

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
closes #148 
