### PR TITLE
[refactor] #154 닉네임 수정 API, 회원탈퇴 API에서 토큰을 받아 로직을 수행하도록 리팩토링 완료

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/MyPageController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/MyPageController.java
@@ -80,8 +80,8 @@ public class MyPageController {
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PutMapping("/nickname/change")
-    public ResponseEntity<NicknameModifyResponse> changeNickname(@RequestBody NicknameModifyRequest nicknameModifyRequest) {
-        NicknameModifyResponse response = myPageService.changeNickname(nicknameModifyRequest);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+    public ResponseEntity<Map<String, NicknameModifyResponse>> changeNickname(@RequestHeader("Authorization") String authorizationHeader, @RequestBody NicknameModifyRequest nicknameModifyRequest) {
+        NicknameModifyResponse response = myPageService.changeNickname(authorizationHeader, nicknameModifyRequest);
+        return new ResponseEntity<>(Map.of("nicknameModifyResponse", response), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/UserController.java
@@ -135,8 +135,8 @@ public class UserController {
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @DeleteMapping
-    public ResponseEntity<Void> deleteUser(@RequestBody DeleteUserRequest deleteUserRequest) {
-        userService.deleteUser(deleteUserRequest.userId());
+    public ResponseEntity<Void> deleteUser(@RequestHeader("Authorization") String authorizationHeader) {
+        userService.deleteUserByToken(authorizationHeader);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/MyPageService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/MyPageService.java
@@ -99,9 +99,13 @@ public class MyPageService {
     }
 
     @Transactional
-    public NicknameModifyResponse changeNickname(NicknameModifyRequest nicknameModifyRequest) {
-        User user = userRepository.findById(nicknameModifyRequest.userId())
+    public NicknameModifyResponse changeNickname(String authorizationHeader, NicknameModifyRequest nicknameModifyRequest) {
+        String token = jwtProvider.getTokenFromAuthorizationHeader(authorizationHeader);
+        Long userId = jwtProvider.getUserIdFromToken(token);
+
+        User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
+
         user.setUserNickname(nicknameModifyRequest.newNickname());
         userRepository.save(user);
 

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
@@ -172,6 +172,13 @@ public class UserService {
     }
 
     @Transactional
+    public void deleteUserByToken(String authorizationHeader) {
+        String token = jwtProvider.getTokenFromAuthorizationHeader(authorizationHeader);
+        Long userId = jwtProvider.getUserIdFromToken(token);
+        deleteUser(userId);
+    }
+
+    @Transactional
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(
                 () -> new UserNotFoundException());

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameModifyRequest.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameModifyRequest.java
@@ -1,7 +1,6 @@
 package com.moodmate.moodmatebe.domain.user.dto;
 
 public record NicknameModifyRequest(
-        Long userId,
         String newNickname
 ) {
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 전에는 RequestBody로 userId를 받아 해당 사용자의 닉네임을 수정할 수 있고, 회원탈퇴를 수행할 수 있도록 구현했지만, 프론트측에서 userId를 가지고 있지 않기 때문에, 토큰을 받고 그 토큰으로 user를 식별해서 로직을 수행하도록 변경했습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
- closes #153 
