### PR TITLE
[refactor] #157 모든 사용자의 닉네임이 다르도록 하는 중복체크 api 리팩토링 완료

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/user/api/MyPageController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/api/MyPageController.java
@@ -66,8 +66,8 @@ public class MyPageController {
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/nickname/check")
-    public ResponseEntity<NicknameCheckResponse> checkDuplicateNickname(@RequestBody NicknameCheckRequest nicknameCheckRequest) {
-        NicknameCheckResponse response = myPageService.checkDuplicateNickname(nicknameCheckRequest);
+    public ResponseEntity<NicknameCheckResponse> checkDuplicateNickname(@RequestHeader("Authorization") String authorizationHeader, @RequestBody NicknameCheckRequest nicknameCheckRequest) {
+        NicknameCheckResponse response = myPageService.checkDuplicateNickname(authorizationHeader, nicknameCheckRequest);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/MyPageService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/MyPageService.java
@@ -89,10 +89,13 @@ public class MyPageService {
     }
 
     @Transactional
-    public NicknameCheckResponse checkDuplicateNickname(NicknameCheckRequest nicknameCheckRequest) {
-        List<User> usersWithSameNickname = userRepository.findByUserNicknameAndUserGenderAndUserPreferMood(
-                nicknameCheckRequest.userNickname(), nicknameCheckRequest.userGender(), nicknameCheckRequest.preferMood());
-        if (!usersWithSameNickname.isEmpty()) {
+    public NicknameCheckResponse checkDuplicateNickname(String authorizationHeader, NicknameCheckRequest nicknameCheckRequest) {
+        String token = jwtProvider.getTokenFromAuthorizationHeader(authorizationHeader);
+        Long userId = jwtProvider.getUserIdFromToken(token);
+
+        boolean isNicknameDuplicate  = userRepository.existsByUserNicknameExceptUserId(
+                nicknameCheckRequest.userNickname(), userId);
+        if (isNicknameDuplicate) {
             return new NicknameCheckResponse(true, "닉네임이 중복되었습니다.");
         }
         return new NicknameCheckResponse(false, "닉네임이 중복되지 않았습니다.");

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameCheckRequest.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/dto/NicknameCheckRequest.java
@@ -1,10 +1,6 @@
 package com.moodmate.moodmatebe.domain.user.dto;
 
-import com.moodmate.moodmatebe.domain.user.domain.Gender;
-
 public record NicknameCheckRequest(
-        String userNickname,
-        String preferMood,
-        Gender userGender
+        String userNickname
 ) {
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/repository/UserRepository.java
@@ -1,18 +1,17 @@
 package com.moodmate.moodmatebe.domain.user.repository;
 
-import com.moodmate.moodmatebe.domain.user.domain.Gender;
 import com.moodmate.moodmatebe.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long userId);
+
     Optional<User> findByUserEmail(String userEmail);
 
-    @Query("SELECT u FROM User u JOIN u.prefer p WHERE u.userNickname = :nickname AND u.userGender = :gender AND p.preferMood = :mood")
-    List<User> findByUserNicknameAndUserGenderAndUserPreferMood(@Param("nickname") String userNickname, @Param("gender") Gender userGender, @Param("mood") String userPreferMood);
+    @Query("SELECT COUNT(u) > 0 FROM User u WHERE u.userNickname = :userNickname AND u.userId <> :userId")
+    boolean existsByUserNicknameExceptUserId(@Param("userNickname") String userNickname, @Param("userId") Long userId);
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 전체 중복 체크 기능을 도입하여 개발팀에서 중복되는 인원들은 임의로 닉네임을 변경해주고, 수정 api로 닉네임을 변경할 수 있도록 하는 방향으로 회의를 통해 결정하게 되어 코드를 변경했습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 기존에는 유저의 토큰을 받지 않고, userNickname만 requestBody로 받아서 중복체크를 하도록 진행했는데, 본인의 닉네임까지도 중복으로 판단하게 되는 문제가 있었습니다.
- 따라서 헤더로 토큰을 받아, userId를 가져오고, JPA 메서드를 이용해 해당 userId는 로직에서 제외하고 중복 체크를 하는 방식으로 구현하여 해결할 수 있었습니다.

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
- closes #156 