### PR TITLE
[Fix] #160 매칭 알고리즘이 작동하는 중간에 사용자가 탈퇴하지 못하도록 막기

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/matching/api/MatchingController.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/matching/api/MatchingController.java
@@ -11,10 +11,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MatchingController {
     private final MatchingService matchingService;
+
     @Scheduled(cron = "00 50 21 * * *", zone = "Asia/Seoul")
     public void runMatchingAlgorithm() {
         log.info("Matching start");
         matchingService.match();
-        matchingService.grouping();
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/application/UserService.java
@@ -14,6 +14,7 @@ import com.moodmate.moodmatebe.domain.user.dto.PartnerResponse;
 import com.moodmate.moodmatebe.domain.user.dto.PreferInfoRequest;
 import com.moodmate.moodmatebe.domain.user.dto.UserInfoRequest;
 import com.moodmate.moodmatebe.domain.user.exception.InvalidInputValueException;
+import com.moodmate.moodmatebe.domain.user.exception.UserMatchingInProgressException;
 import com.moodmate.moodmatebe.domain.user.exception.UserNotFoundException;
 import com.moodmate.moodmatebe.domain.user.repository.PreferRepository;
 import com.moodmate.moodmatebe.domain.user.repository.UserRepository;
@@ -182,6 +183,10 @@ public class UserService {
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(
                 () -> new UserNotFoundException());
+
+        if (user.isMatchInProgress()) {
+            throw new UserMatchingInProgressException();
+        }
 
         notificationRepository.deleteByUser(user);
         roomRepository.deleteByUser1OrUser2(user, user);

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/domain/User.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/domain/User.java
@@ -71,6 +71,14 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Authority authority;
 
+    @Column(name = "match_in_progress")
+    @ColumnDefault("false")
+    private Boolean matchInProgress;
+
+    public boolean isMatchInProgress() {
+        return Boolean.TRUE.equals(matchInProgress);
+    }
+
     public static User toUser(OAuthInfoResponse oAuthInfoResponse) {
         return User
                 .builder()
@@ -78,6 +86,7 @@ public class User extends BaseTimeEntity {
                 .userEmail(oAuthInfoResponse.getEmail())
                 .userProfileImageUrl(oAuthInfoResponse.getProfileImageUrl())
                 .authority(Authority.ROLE_USER)
+                .matchInProgress(false)
                 .build();
     }
 }

--- a/src/main/java/com/moodmate/moodmatebe/domain/user/exception/UserMatchingInProgressException.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/user/exception/UserMatchingInProgressException.java
@@ -1,0 +1,8 @@
+package com.moodmate.moodmatebe.domain.user.exception;
+
+import com.moodmate.moodmatebe.global.error.ErrorCode;
+import com.moodmate.moodmatebe.global.error.exception.ServiceException;
+
+public class UserMatchingInProgressException extends ServiceException {
+    public UserMatchingInProgressException() {super(ErrorCode.USER_MATCH_IN_PROGRESS);}
+}

--- a/src/main/java/com/moodmate/moodmatebe/global/error/ErrorCode.java
+++ b/src/main/java/com/moodmate/moodmatebe/global/error/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
     CHAT_ROOM_UNAUTHORIZED(401, "CHAT_ROOM_UNAUTHORIZED","권한이 없는 채팅방입니다."),
     FIREBASE_TOKEN_NOT_FOUND(404, "FIREBASE_TOKEN_NOT_FOUND","파이어베이스토큰이 존재하지않습니다."),
     SAVE_CHAT_ROOM_ERROR(500, "SAVE_CHAT_ROOM_ERROR", "채팅방을 저장하는 동안 오류가 발생했습니다."),
-    SAVE_MEETING_RECORD_ERROR(500, "SAVE_MEETING_RECORD_ERROR", "만남 기록을 저장하는 동안 오류가 발생했습니다.");
+    SAVE_MEETING_RECORD_ERROR(500, "SAVE_MEETING_RECORD_ERROR", "만남 기록을 저장하는 동안 오류가 발생했습니다."),
+    USER_MATCH_IN_PROGRESS(400, "USER_MATCH_IN_PROGRESS", "사용자가 현재 매칭 과정에 있어 삭제할 수 없습니다.");
 
     private final int httpStatus;
     private final String code;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 사용자가 매칭 알고리즘 작동시간에 탈퇴를 하지 못하도록 막기 위해서 변경했습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- flush()를 도입하기 전에는 true로 변경되는 과정과 false로 변경되는 과정이 한꺼번에 처리되었습니다.
- 그래서 EntityManger를 이용해 영속성 컨텍스트에 있는 내용을 flush를 명시적으로 호출하여 true와 false의 변경 과정을 각각 DB에 처리하도록 했습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="920" alt="image" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/ea42b878-2f63-46ca-8513-2bc607e2eba4">

- users 테이블에서 사용자의 match_in_progress 상태가 변경될 때마다 그 변경 내역을 user_status_change_log 테이블에 자동으로 기록하는 트리거를 설정하였습니다.

<img width="728" alt="image" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/85a9aa7b-cd77-43b0-b821-7995fcb8f7be">

- matchInProgress 필드가 false에서 true로 DB에 반영이 된 횟수를 보여주는 쿼리문으로, 정상적으로 사용자의 상태가 false에서 true로 변경되었음을 볼 수 있습니다.

<img width="713" alt="image" src="https://github.com/Leets-Official/MoodMate-BE/assets/125895298/e3410031-b3d8-4855-92d8-55a8889214af">

- matchInProgress 필드가 true에서 false로 DB에 반영이 된 횟수를 보여주는 쿼리문으로, 정상적으로 사용자의 상태가 true에서 false로 변경되었음을 볼 수 있습니다.

<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
- flush()를 명시적으로 호출하여 반영하는 방법보다는 트랜잭션이 끝나면 자동적으로 flush와 commit가 호출되어 DB에 반영되도록 하는 방법이 권장되는 것 같습니다.
- 하지만, 그렇게 별도의 트랜잭션으로 관리를 하려고 했지만 LazyInitializationException이 발생하였고, DTO를 사용해서 추후 리팩토링을 할 예정입니다.

closes #159 