### PR TITLE
[Refactor] #163 채팅메시지 인증인가 로직 변경

### DIFF
--- a/src/main/java/com/moodmate/moodmatebe/domain/chat/dto/request/ChatMessageDto.java
+++ b/src/main/java/com/moodmate/moodmatebe/domain/chat/dto/request/ChatMessageDto.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 public class ChatMessageDto {
     private String content;
     private Long roomId;
-    private String token;
+   // private String token;
     private Long userId;
     //private LocalDateTime createdAt;
     //private boolean isRead;

--- a/src/main/java/com/moodmate/moodmatebe/global/config/WebSocketConfig.java
+++ b/src/main/java/com/moodmate/moodmatebe/global/config/WebSocketConfig.java
@@ -1,8 +1,10 @@
 package com.moodmate.moodmatebe.global.config;
 
+import com.moodmate.moodmatebe.global.handler.StompHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -12,6 +14,9 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompHandler stompHandler;
+
     @Value("${websocket.allowedOrigins}")
     private String allowedOrigins;
     @Override
@@ -27,6 +32,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.setApplicationDestinationPrefixes("/pub");
         //해당 주소를 구독하고 있는 클라이언트에게 메시지 전달
         registry.enableSimpleBroker("/sub");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompHandler);
     }
 
 }

--- a/src/main/java/com/moodmate/moodmatebe/global/handler/StompHandler.java
+++ b/src/main/java/com/moodmate/moodmatebe/global/handler/StompHandler.java
@@ -1,0 +1,37 @@
+package com.moodmate.moodmatebe.global.handler;
+
+
+import com.moodmate.moodmatebe.domain.user.exception.UserNotFoundException;
+import com.moodmate.moodmatebe.global.jwt.JwtProvider;
+import com.moodmate.moodmatebe.global.jwt.exception.InvalidTokenException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StompHandler implements ChannelInterceptor {
+    private final JwtProvider jwtProvider;
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        log.info("message:",message);
+        log.info("header : ",message.getHeaders());
+        log.info("token:",accessor.getNativeHeader("Authorization"));
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            if(!jwtProvider.validateToken(accessor.getFirstNativeHeader("Authorization").substring(7)))
+                throw new InvalidTokenException();
+        }
+        return message;
+    }
+}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
`@MessageMapping `API는 양방향 프로토콜인 ws를 사용하였는데, 헤더에서 JWT 검증이 불가능하였습니다.
그래서 기존의 방법은 body넣은 토큰을 받아 JWT 검증을 하였지만, 토큰을 body에 넣는 것은 보안상 좋지않아 코드를 수정하였습니다.

Stomp를 서브프로토콜로 사용중이였기에 `StompHandler`를 구현하여 헤더에 접근하고, JWT를 검증한 이후 MessageMapping인 `handleMessage`에 접근하도록 구현하였습니다. 

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

<br>

## 4. 완료 사항
- develop 브랜치에서 테스트 하면서 로직을 검증하고, 에러가 난다면 처리해야할 것 같습니다.

<br>

## 5. 추가 사항
close #162 